### PR TITLE
Add support for the Orange Pi Prime

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Machine Images:
 | homeassistant/intel-nuc-homeassistant | amd64 |
 | homeassistant/odroid-c2-homeassistant | aarch64 |
 | homeassistant/odroid-xu-homeassistant | armhf |
+| homeassistant/orangepi-prime-homeassistant | aarch64 |
 | homeassistant/qemuarm-homeassistant | armhf |
 | homeassistant/qemuarm-64-homeassistant | aarch64 |
 | homeassistant/qemux86-homeassistant | i386 |

--- a/README.md
+++ b/README.md
@@ -2,30 +2,30 @@
 Hass.io Home Assistant container
 
 Base Images:
-- homeassistant/amd64-homeassistant-base:latest
-- homeassistant/i386-homeassistant-base:latest
-- homeassistant/armhf-homeassistant-base:latest
 - homeassistant/aarch64-homeassistant-base:latest
+- homeassistant/amd64-homeassistant-base:latest
+- homeassistant/armhf-homeassistant-base:latest
+- homeassistant/i386-homeassistant-base:latest
 
 Generic Images:
-- homeassistant/amd64-homeassistant-base:_REL-VERSION_
-- homeassistant/i386-homeassistant-base:_REL-VERSION_
-- homeassistant/armhf-homeassistant-base:_REL-VERSION_
 - homeassistant/aarch64-homeassistant-base:_REL-VERSION_
+- homeassistant/amd64-homeassistant-base:_REL-VERSION_
+- homeassistant/armhf-homeassistant-base:_REL-VERSION_
+- homeassistant/i386-homeassistant-base:_REL-VERSION_
 
 Machine Images:
 
 | Image | Arch |
 |-------|------|
-| homeassistant/qemux86-homeassistant | i386 |
-| homeassistant/qemux86-64-homeassistant | amd64 |
+| homeassistant/intel-nuc-homeassistant | amd64 |
+| homeassistant/odroid-c2-homeassistant | aarch64 |
+| homeassistant/odroid-xu-homeassistant | armhf |
 | homeassistant/qemuarm-homeassistant | armhf |
 | homeassistant/qemuarm-64-homeassistant | aarch64 |
-| homeassistant/intel-nuc-homeassistant | amd64 |
+| homeassistant/qemux86-homeassistant | i386 |
+| homeassistant/qemux86-64-homeassistant | amd64 |
 | homeassistant/raspberrypi-homeassistant | armhf |
 | homeassistant/raspberrypi2-homeassistant | armhf |
 | homeassistant/raspberrypi3-homeassistant | armhf |
 | homeassistant/raspberrypi3-64-homeassistant | aarch64 |
 | homeassistant/tinker-homeassistant | armhf |
-| homeassistant/odroid-c2-homeassistant | aarch64 |
-| homeassistant/odroid-xu-homeassistant | armhf |

--- a/machine/orangepi-prime
+++ b/machine/orangepi-prime
@@ -1,0 +1,4 @@
+ARG BUILD_VERSION
+FROM homeassistant/aarch64-homeassistant:$BUILD_VERSION
+
+RUN apk --no-cache add usbutils


### PR DESCRIPTION
This PR sorts the image alphabetically, and adds support for the Orange Pi Prime.