### PR TITLE
Add generic platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Machine Images:
 
 | Image | Arch |
 |-------|------|
+| homeassistant/generic-aarch64-homeassistant | aarch64 |
+| homeassistant/generic-amd64-homeassistant | amd64 |
+| homeassistant/generic-armhf-homeassistant | armhf |
+| homeassistant/generic-x86-homeassistant | i386 |
 | homeassistant/intel-nuc-homeassistant | amd64 |
 | homeassistant/odroid-c2-homeassistant | aarch64 |
 | homeassistant/odroid-xu-homeassistant | armhf |

--- a/machine/generic-aarch64
+++ b/machine/generic-aarch64
@@ -1,0 +1,4 @@
+ARG BUILD_VERSION
+FROM homeassistant/aarch64-homeassistant:$BUILD_VERSION
+
+RUN apk --no-cache add usbutils

--- a/machine/generic-amd64
+++ b/machine/generic-amd64
@@ -1,0 +1,22 @@
+ARG BUILD_VERSION
+FROM homeassistant/amd64-homeassistant:$BUILD_VERSION
+
+RUN apk --no-cache add usbutils
+
+##
+# Build libcec for HDMI-CEC
+ARG LIBCEC_VERSION=4.0.3
+RUN apk add --no-cache eudev-libs p8-platform \
+    && apk add --no-cache --virtual .build-dependencies \
+        build-base cmake eudev-dev git swig p8-platform-dev \
+    && git clone --depth 1 -b libcec-${LIBCEC_VERSION} https://github.com/Pulse-Eight/libcec /usr/src/libcec \
+    && mkdir -p /usr/src/libcec/build \
+    && cd /usr/src/libcec/build \
+    && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
+        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.6m.so" \
+        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.6m" .. \
+    && make -j$(nproc) \
+    && make install \
+    && echo "cec" > "/usr/local/lib/python3.6/site-packages/cec.pth" \
+    && apk del .build-dependencies \
+    && rm -rf /usr/src/libcec

--- a/machine/generic-armhf
+++ b/machine/generic-armhf
@@ -1,0 +1,4 @@
+ARG BUILD_VERSION
+FROM homeassistant/armhf-homeassistant:$BUILD_VERSION
+
+RUN apk --no-cache add usbutils

--- a/machine/generic-i386
+++ b/machine/generic-i386
@@ -1,0 +1,22 @@
+ARG BUILD_VERSION
+FROM homeassistant/i386-homeassistant:$BUILD_VERSION
+
+RUN apk --no-cache add usbutils
+
+##
+# Build libcec for HDMI-CEC
+ARG LIBCEC_VERSION=4.0.3
+RUN apk add --no-cache eudev-libs p8-platform \
+    && apk add --no-cache --virtual .build-dependencies \
+        build-base cmake eudev-dev git swig p8-platform-dev \
+    && git clone --depth 1 -b libcec-${LIBCEC_VERSION} https://github.com/Pulse-Eight/libcec /usr/src/libcec \
+    && mkdir -p /usr/src/libcec/build \
+    && cd /usr/src/libcec/build \
+    && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
+        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.6m.so" \
+        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.6m" .. \
+    && make -j$(nproc) \
+    && make install \
+    && echo "cec" > "/usr/local/lib/python3.6/site-packages/cec.pth" \
+    && apk del .build-dependencies \
+    && rm -rf /usr/src/libcec


### PR DESCRIPTION
Thinking a bit more about @pvizeli 's suggestion about 'orangepi-h5', I came to the conclusion that having some clearly labelled generic platforms would be helpful.

I spent quite some trying trying to figure out how the specify which machine to use on my (then unsupported) Orange Pi Prime, before realising that the qemu machine was fairly generic.

This patch adds some generic platforms that can either be used outright, or as a template for new boards.