### PR TITLE
Bump arp-scan from 1.9.5 to 1.9.6 in /base

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -77,7 +77,7 @@ RUN apk add --no-cache \
     && rm -rf /usr/src/ssocr
 
 # arp-scan
-ARG ARPSCAN_VERSION=1.9.5
+ARG ARPSCAN_VERSION=1.9.6
 RUN apk add --no-cache \
         libpcap \
     && apk add --no-cache --virtual .build-dependencies \


### PR DESCRIPTION
Bumps arp-scan from 1.9.5 to 1.9.6 to fix an issue with libpcap and not generating any output.