### PR TITLE
Add FreeTDS driver to base Dockerfile

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -55,7 +55,10 @@ RUN apk add --no-cache \
 
 ###
 # Create /etc/odbcinst.ini for FreeTDS ODBC driver
-RUN echo -e "[FreeTDS]\nDescription = FreeTDS unixODBC Driver\nDriver = /usr/lib/libtdsodbc.so.0\nSetup = /usr/lib/libtdsodbc.so.0\nUsageCount = 1" >> /etc/odbcinst.ini
+RUN echo -e "[FreeTDS]\nDescription = FreeTDS unixODBC Driver" \
+    + "\nDriver = /usr/lib/libtdsodbc.so.0" \
+    + "\nSetup = /usr/lib/libtdsodbc.so.0" \
+    + "\nUsageCount = 1" >> /etc/odbcinst.ini
 
 ####
 ## Install pip module for component/homeassistant

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -32,6 +32,7 @@ RUN apk add --no-cache \
     curl \
     ffmpeg \
     ffmpeg-libs \
+    freetds \
     git \
     glib \
     gmp \
@@ -51,6 +52,10 @@ RUN apk add --no-cache \
     socat \
     unixodbc \
     zlib
+
+###
+# Create /etc/odbcinst.ini for FreeTDS ODBC driver
+RUN echo -e "[FreeTDS]\nDescription = FreeTDS unixODBC Driver\nDriver = /usr/lib/libtdsodbc.so.0\nSetup = /usr/lib/libtdsodbc.so.0\nUsageCount = 1" >> /etc/odbcinst.ini
 
 ####
 ## Install pip module for component/homeassistant

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -55,10 +55,7 @@ RUN apk add --no-cache \
 
 ###
 # Create /etc/odbcinst.ini for FreeTDS ODBC driver
-RUN echo -e "[FreeTDS]\nDescription = FreeTDS unixODBC Driver" \
-    + "\nDriver = /usr/lib/libtdsodbc.so.0" \
-    + "\nSetup = /usr/lib/libtdsodbc.so.0" \
-    + "\nUsageCount = 1" >> /etc/odbcinst.ini
+COPY odbcinst.ini /etc/
 
 ####
 ## Install pip module for component/homeassistant

--- a/base/odbcinst.ini
+++ b/base/odbcinst.ini
@@ -1,5 +1,5 @@
 [FreeTDS]
-Description = FreeTDS unixODBC Driver"
-Driver      = /usr/lib/libtdsodbc.so.0"
-Setup       = /usr/lib/libtdsodbc.so.0"
+Description = FreeTDS unixODBC Driver
+Driver      = /usr/lib/libtdsodbc.so.0
+Setup       = /usr/lib/libtdsodbc.so.0
 UsageCount  = 1

--- a/base/odbcinst.ini
+++ b/base/odbcinst.ini
@@ -1,0 +1,5 @@
+[FreeTDS]
+Description = FreeTDS unixODBC Driver"
+Driver      = /usr/lib/libtdsodbc.so.0"
+Setup       = /usr/lib/libtdsodbc.so.0"
+UsageCount  = 1


### PR DESCRIPTION
Adding FreeTDS ODBC driver and /etc/odbcinst.ini file to define the driver for ODBC connections. This is in response to pymssql no longer being maintained and incompatible with Python 3.7. This will allow users to switch over to pyODBC and the FreeTDS driver when connecting the recorder component to an MS SQL database.