### PR TITLE
Add bluez to alpine base image build

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -20,6 +20,7 @@ RUN apk add --no-cache \
         musl \
         openssl \
         tiff \
+        bluez \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h
 
 ##


### PR DESCRIPTION
python 3 has native support for bluetooth sockets, with [socket family AF_BLUETOOTH](https://docs.python.org/3/library/socket.html#socket-families)

However, it only has support for it if built with `bluetooth.h` in the dependencies 

Before:
```
>>> from socket import AF_BLUETOOTH"
  File "<stdin>", line 1
    from socket import AF_BLUETOOTH"
                                   ^
SyntaxError: EOL while scanning string literal
>>> from socket import AF_BLUETOOTH
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'AF_BLUETOOTH' from 'socket' (/usr/local/lib/python3.7/socket.py)
```

After:
```
Python 3.7.6 (default, Dec 21 2019, 23:33:58) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from socket import AF_BLUETOOTH
>>> AF_BLUETOOTH
<AddressFamily.AF_BLUETOOTH: 31>
>>> 
```