### PR TITLE
Install libgammu-dev

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -37,6 +37,7 @@ RUN apk add --no-cache \
     glib \
     gmp \
     iperf3 \
+    libgammu-dev \
     libsodium \
     libwebp \
     libxml2 \


### PR DESCRIPTION
In order to develop a local (no internet required) SMS integration with gammu we need to install libgammu-dev so that the python gammu library can be installed.

Here is my [work in progress](https://github.com/ocalvo/ha-sms/blob/master/custom_components/sms/manifest.json)