### PR TITLE
add packages for Intel NUC iGPU access in Hassio

### DIFF
--- a/machine/intel-nuc
+++ b/machine/intel-nuc
@@ -7,7 +7,7 @@ RUN apk --no-cache add \
 ##
 # Build libcec for HDMI-CEC
 ARG LIBCEC_VERSION=4.0.4
-RUN apk add --no-cache eudev-libs libva libva-intel-driver p8-platform \
+RUN apk add --no-cache eudev-libs libva-intel-driver p8-platform \
     && apk add --no-cache --virtual .build-dependencies \
         build-base cmake eudev-dev swig p8-platform-dev \
     && git clone --depth 1 -b libcec-${LIBCEC_VERSION} https://github.com/Pulse-Eight/libcec /usr/src/libcec \

--- a/machine/intel-nuc
+++ b/machine/intel-nuc
@@ -7,7 +7,7 @@ RUN apk --no-cache add \
 ##
 # Build libcec for HDMI-CEC
 ARG LIBCEC_VERSION=4.0.4
-RUN apk add --no-cache eudev-libs p8-platform \
+RUN apk add --no-cache eudev-libs libva libva-intel-driver p8-platform \
     && apk add --no-cache --virtual .build-dependencies \
         build-base cmake eudev-dev swig p8-platform-dev \
     && git clone --depth 1 -b libcec-${LIBCEC_VERSION} https://github.com/Pulse-Eight/libcec /usr/src/libcec \

--- a/machine/intel-nuc
+++ b/machine/intel-nuc
@@ -2,12 +2,13 @@ ARG BUILD_VERSION
 FROM homeassistant/amd64-homeassistant:$BUILD_VERSION
 
 RUN apk --no-cache add \
+    libva-intel-driver \
     usbutils
 
 ##
 # Build libcec for HDMI-CEC
 ARG LIBCEC_VERSION=4.0.4
-RUN apk add --no-cache eudev-libs libva-intel-driver p8-platform \
+RUN apk add --no-cache eudev-libs p8-platform \
     && apk add --no-cache --virtual .build-dependencies \
         build-base cmake eudev-dev swig p8-platform-dev \
     && git clone --depth 1 -b libcec-${LIBCEC_VERSION} https://github.com/Pulse-Eight/libcec /usr/src/libcec \


### PR DESCRIPTION
Packages needed:
libva 
libva-intel-driver

### Test with docker image homeassistant/intel-nuc-homeassistant:0.104.2
```
docker run --rm -ti --device /dev/dri:/dev/dri -v --entrypoint='sh' homeassistant/intel-nuc-homeassistant:0.104.2 sh
```

### Check included ffmpeg for vaapi support:
```
/config # ffmpeg -hide_banner -encoders | grep vaapi  
 V..... h264_vaapi           H.264/AVC (VAAPI) (codec h264)  
 V..... hevc_vaapi           H.265/HEVC (VAAPI) (codec hevc)  
 V..... mjpeg_vaapi          MJPEG (VAAPI) (codec mjpeg)  
 V..... mpeg2_vaapi          MPEG-2 (VAAPI) (codec mpeg2video)  
 V..... vp8_vaapi            VP8 (VAAPI) (codec vp8)  
 V..... vp9_vaapi            VP9 (VAAPI) (codec vp9)
```

### Run ffmpeg with vaapi but fails:
```
/config # ffmpeg -hide_banner -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -i http://192.168.1.15:8766/ -f null -
[AVHWDeviceContext @ 0x7fd8a9bcdc40] Failed to initialise VAAPI connection: -1 (unknown libva error).
Device creation failed: -5.
Failed to set value '/dev/dri/renderD128' for option 'vaapi_device': I/O error
Error parsing global options: I/O error
```

### add packages (194MB added to image):
```
/config # apk add libva libva-intel-driver
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/1) Installing libva-intel-driver (2.3.0-r0)
OK: 194 MiB in 156 packages
```

### test ffmpeg again with new packages, success:
```
/config # ffmpeg -hide_banner -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -i http://192.168.1.15:8766/ -f null -
Input #0, mpjpeg, from 'http://192.168.1.15:8766/':
  Duration: N/A, bitrate: N/A
    Stream #0:0: Video: mjpeg, yuvj420p(pc, bt470bg/unknown/unknown), 1440x960 [SAR 1:1 DAR 3:2], 25 tbr, 25 tbn, 25 tbc
Stream mapping:
  Stream #0:0 -> #0:0 (mjpeg (native) -> wrapped_avframe (native))
Press [q] to stop, [?] for help
Output #0, null, to 'pipe:':
  Metadata:
    encoder         : Lavf58.20.100
    Stream #0:0: Video: wrapped_avframe, yuv420p, 1440x960 [SAR 1:1 DAR 3:2], q=2-31, 200 kb/s, 25 fps, 25 tbn, 25 tbc
    Metadata:
      encoder         : Lavc58.35.100 wrapped_avframe
frame=  203 fps= 24 q=-0.0 Lsize=N/A time=00:00:08.12 bitrate=N/A speed=0.962x
video:106kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
Exiting normally
```