### PR TITLE
Build libcec for HDMI-CEC on QEMU machine platforms

### DIFF
--- a/machine/qemuarm
+++ b/machine/qemuarm
@@ -3,3 +3,21 @@ FROM homeassistant/armhf-homeassistant:$BUILD_VERSION
 
 RUN apk --no-cache add \
     usbutils
+
+##
+# Build libcec for HDMI-CEC
+ARG LIBCEC_VERSION=4.0.4
+RUN apk add --no-cache eudev-libs p8-platform \
+    && apk add --no-cache --virtual .build-dependencies \
+        build-base cmake eudev-dev swig p8-platform-dev \
+    && git clone --depth 1 -b libcec-${LIBCEC_VERSION} https://github.com/Pulse-Eight/libcec /usr/src/libcec \
+    && mkdir -p /usr/src/libcec/build \
+    && cd /usr/src/libcec/build \
+    && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
+        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.7m.so" \
+        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.7m" .. \
+    && make -j$(nproc) \
+    && make install \
+    && echo "cec" > "/usr/local/lib/python3.7/site-packages/cec.pth" \
+    && apk del .build-dependencies \
+    && rm -rf /usr/src/libcec

--- a/machine/qemuarm-64
+++ b/machine/qemuarm-64
@@ -3,3 +3,21 @@ FROM homeassistant/aarch64-homeassistant:$BUILD_VERSION
 
 RUN apk --no-cache add \
     usbutils
+
+##
+# Build libcec for HDMI-CEC
+ARG LIBCEC_VERSION=4.0.4
+RUN apk add --no-cache eudev-libs p8-platform \
+    && apk add --no-cache --virtual .build-dependencies \
+        build-base cmake eudev-dev swig p8-platform-dev \
+    && git clone --depth 1 -b libcec-${LIBCEC_VERSION} https://github.com/Pulse-Eight/libcec /usr/src/libcec \
+    && mkdir -p /usr/src/libcec/build \
+    && cd /usr/src/libcec/build \
+    && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
+        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.7m.so" \
+        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.7m" .. \
+    && make -j$(nproc) \
+    && make install \
+    && echo "cec" > "/usr/local/lib/python3.7/site-packages/cec.pth" \
+    && apk del .build-dependencies \
+    && rm -rf /usr/src/libcec

--- a/machine/qemux86
+++ b/machine/qemux86
@@ -3,3 +3,21 @@ FROM homeassistant/i386-homeassistant:$BUILD_VERSION
 
 RUN apk --no-cache add \
     usbutils
+
+##
+# Build libcec for HDMI-CEC
+ARG LIBCEC_VERSION=4.0.4
+RUN apk add --no-cache eudev-libs p8-platform \
+    && apk add --no-cache --virtual .build-dependencies \
+        build-base cmake eudev-dev swig p8-platform-dev \
+    && git clone --depth 1 -b libcec-${LIBCEC_VERSION} https://github.com/Pulse-Eight/libcec /usr/src/libcec \
+    && mkdir -p /usr/src/libcec/build \
+    && cd /usr/src/libcec/build \
+    && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
+        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.7m.so" \
+        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.7m" .. \
+    && make -j$(nproc) \
+    && make install \
+    && echo "cec" > "/usr/local/lib/python3.7/site-packages/cec.pth" \
+    && apk del .build-dependencies \
+    && rm -rf /usr/src/libcec

--- a/machine/qemux86-64
+++ b/machine/qemux86-64
@@ -3,3 +3,21 @@ FROM homeassistant/amd64-homeassistant:$BUILD_VERSION
 
 RUN apk --no-cache add \
     usbutils
+
+##
+# Build libcec for HDMI-CEC
+ARG LIBCEC_VERSION=4.0.4
+RUN apk add --no-cache eudev-libs p8-platform \
+    && apk add --no-cache --virtual .build-dependencies \
+        build-base cmake eudev-dev swig p8-platform-dev \
+    && git clone --depth 1 -b libcec-${LIBCEC_VERSION} https://github.com/Pulse-Eight/libcec /usr/src/libcec \
+    && mkdir -p /usr/src/libcec/build \
+    && cd /usr/src/libcec/build \
+    && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
+        -DPYTHON_LIBRARY="/usr/local/lib/libpython3.7m.so" \
+        -DPYTHON_INCLUDE_DIR="/usr/local/include/python3.7m" .. \
+    && make -j$(nproc) \
+    && make install \
+    && echo "cec" > "/usr/local/lib/python3.7/site-packages/cec.pth" \
+    && apk del .build-dependencies \
+    && rm -rf /usr/src/libcec


### PR DESCRIPTION
Tested by running the same commands manually inside homeassistant container (see attached file [qemu-libcec-test.txt](https://github.com/home-assistant/hassio-homeassistant/files/4109308/qemu-libcec-test.txt)) and confirming libcec existed afterwards.  Also, restarted Home Assistant and confirmed that HDMI-CEC integration was working and that `ModuleNotFoundError: No module named 'cec'` error did not occur.

Fixes #84.

