### PR TITLE
Dockerfile add patch bump telldus minimum CMake to 3.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,7 @@ ARG BUILD_FROM
 WORKDIR /tmp/
 COPY patches/telldus-fix-gcc-11-issues.patch /tmp/
 COPY patches/telldus-fix-alpine-3-17-issues.patch /tmp/
+COPY patches/telldus-bump-cmake-minimum-required-version-to-3100.patch /tmp/
 # hadolint ignore=DL3019
 RUN \
     --mount=type=cache,target=/etc/apk/cache,sharing=locked,id=apk-cache-${BUILD_FROM} \
@@ -105,6 +106,7 @@ RUN git clone https://github.com/telldus/telldus \
     && git reset --hard "${TELLDUS_COMMIT}" \
     && git apply ../telldus-fix-gcc-11-issues.patch \
     && git apply ../telldus-fix-alpine-3-17-issues.patch \
+    && git apply ../telldus-bump-cmake-minimum-required-version-to-3100.patch \
     && cd telldus-core \
     && mkdir /opt/telldus \
     && cmake . -DBUILD_LIBTELLDUS-CORE=ON \

--- a/patches/telldus-bump-cmake-minimum-required-version-to-3100.patch
+++ b/patches/telldus-bump-cmake-minimum-required-version-to-3100.patch
@@ -1,0 +1,86 @@
+From e83d07446e838167fc9214a762b8d3d2d05df671 Mon Sep 17 00:00:00 2001
+From: E Shattow <e@freeshell.de>
+Date: Mon, 27 Apr 2026 12:45:40 -0700
+Subject: [PATCH] Bump CMake minimum required version to 3.10.0
+
+---
+ rfcmd/CMakeLists.txt               | 2 +-
+ telldus-core/CMakeLists.txt        | 4 ++--
+ telldus-core/INSTALL               | 2 +-
+ telldus-gui/CMakeLists.txt         | 2 +-
+ telldus-gui/Plugins/CMakeLists.txt | 2 +-
+ xpl/qtxpl/CMakeLists.txt           | 2 +-
+ 6 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/rfcmd/CMakeLists.txt b/rfcmd/CMakeLists.txt
+index af4b4484..6d8a3dc9 100644
+--- a/rfcmd/CMakeLists.txt
++++ b/rfcmd/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.4)
++cmake_minimum_required( VERSION 3.10.0 )
+ 
+ INCLUDE_DIRECTORIES(
+   /usr/src/linux/include
+diff --git a/telldus-core/CMakeLists.txt b/telldus-core/CMakeLists.txt
+index 5cdd5364..ab524a69 100644
+--- a/telldus-core/CMakeLists.txt
++++ b/telldus-core/CMakeLists.txt
+@@ -1,6 +1,6 @@
+-PROJECT( telldus-core )
++CMAKE_MINIMUM_REQUIRED( VERSION 3.10.0 )
+ 
+-CMAKE_MINIMUM_REQUIRED( VERSION 2.6.0 )
++PROJECT( telldus-core )
+ 
+ CMAKE_POLICY(SET CMP0003 NEW)
+ 
+diff --git a/telldus-core/INSTALL b/telldus-core/INSTALL
+index 9d2b0b4a..035502f1 100644
+--- a/telldus-core/INSTALL
++++ b/telldus-core/INSTALL
+@@ -14,7 +14,7 @@ on some systems it is called gtar.
+ Configuring
+ -----------
+ 
+-Telldus Core is built using CMake (http://www.cmake.org), version 2.4.0 is the
++Telldus Core is built using CMake (http://www.cmake.org), version 3.10.0 is the
+ minimum required version. This means there is no configure-script, but you
+ need to run cmake.
+ 
+diff --git a/telldus-gui/CMakeLists.txt b/telldus-gui/CMakeLists.txt
+index ed193422..fa450842 100644
+--- a/telldus-gui/CMakeLists.txt
++++ b/telldus-gui/CMakeLists.txt
+@@ -1,6 +1,6 @@
+ PROJECT( telldus-gui )
+ 
+-CMAKE_MINIMUM_REQUIRED( VERSION 2.4.0 )
++CMAKE_MINIMUM_REQUIRED( VERSION 3.10.0 )
+ 
+ if(COMMAND cmake_policy)
+ 	cmake_policy(SET CMP0003 NEW)
+diff --git a/telldus-gui/Plugins/CMakeLists.txt b/telldus-gui/Plugins/CMakeLists.txt
+index 382f6744..91ce82d7 100644
+--- a/telldus-gui/Plugins/CMakeLists.txt
++++ b/telldus-gui/Plugins/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ 
+-CMAKE_MINIMUM_REQUIRED( VERSION 2.4.0 )
++CMAKE_MINIMUM_REQUIRED( VERSION 3.10.0 )
+ 
+ SET(BUILD_PLUGIN_TELLDUS-CORE	TRUE	CACHE BOOL "Build plugin 'TelldusCore'")
+ 
+diff --git a/xpl/qtxpl/CMakeLists.txt b/xpl/qtxpl/CMakeLists.txt
+index 480e3796..d9e227ed 100644
+--- a/xpl/qtxpl/CMakeLists.txt
++++ b/xpl/qtxpl/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
++CMAKE_MINIMUM_REQUIRED( VERSION 3.10.0 )
+ PROJECT(qtxpl)
+ 
+ FIND_PACKAGE( Qt4 REQUIRED )
+-- 
+2.50.0
+


### PR DESCRIPTION
Compatibility for CMake versions older than 3.10 is deprecated with previous CMake version 3.31 as distributed with Alpine 3.21 and backwards compatibility for CMake older than 3.5 by overrides and feature flags is now removed. Let's bump the minimum CMake in telldus by patch from 2.4.0 or 2.6 to 3.10.0 as required by CMake 4.0 introduced to Home Assistant CI/CD with Alpine 3.23