### PR TITLE
Dockerfile: set ARG PIP_EXTRA_INDEX_URL to build final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ FROM ${BUILD_FROM}
 
 ARG BUILD_ARCH
 ARG BUILD_FROM
+ARG PIP_EXTRA_INDEX_URL=https://wheels.home-assistant.io/musllinux-index/
 
 ##
 # Install component packages


### PR DESCRIPTION
set ARG PIP_EXTRA_INDEX_URL to allow override from workflow for repository fork and/or customized wheels index