### PR TITLE
Move pip install into dedicated builder stage

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -89,6 +89,8 @@ jobs:
         uses: home-assistant/builder/actions/build-image@62a1597b84b3461abad9816d9cd92862a2b542c3 # 2026.03.2
         with:
           arch: ${{ matrix.arch }}
+          cache-gha: true
+          cache-image-tag: latest
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
           cosign-base-identity: 'https://github.com/home-assistant/docker-base/.*'
           cosign-base-verify: ghcr.io/home-assistant/base-python:3.14-alpine3.22

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,19 @@ RUN git clone https://github.com/telldus/telldus \
     && make install
 
 
+# Build stage for pip packages, installs to /opt/pip-packages
+FROM ${BUILD_FROM} AS pip-builder
+ARG BUILD_FROM
+WORKDIR /tmp/
+RUN \
+    --mount=type=bind,src=./requirements.txt,dst=/tmp/requirements.txt \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-${BUILD_FROM} \
+    pip3 install \
+        --prefix=/opt/pip-packages \
+        --only-binary=:all: \
+        -r /tmp/requirements.txt
+
+
 FROM ${BUILD_FROM}
 
 ARG BUILD_ARCH
@@ -153,15 +166,12 @@ RUN \
         pulseaudio-alsa \
         socat
 
-RUN \
-    --mount=type=bind,src=./requirements.txt,dst=/tmp/requirements.txt \
-    --mount=type=cache,target=/root/.cache/pip,sharing=locked,id=pip-cache-${BUILD_FROM} \
-    pip3 install --only-binary=:all: \
-        -r /tmp/requirements.txt
-
 WORKDIR /usr/src/
 
 ####
+# Copy from pip builder
+COPY --link --from=pip-builder /opt/pip-packages/ /usr/local/
+
 # Copy from ssocr builder
 COPY --link --from=ssocr-builder /opt/ssocr/ /usr/local/
 


### PR DESCRIPTION
## Why

[#343](https://github.com/home-assistant/docker/pull/343) introduced isolated builder stages for ssocr, libcec, PicoTTS, and Telldus, using `COPY --link` to merge them into the final image. The `--link` flag decouples each COPY from the parent layer chain, so a change to the base image or any other stage does not invalidate the cached result of unrelated stages — each builder is independently reusable across builds.

That PR also attempted a `pip-install-builder` stage for Python packages, but it used `pip install --user`, which puts packages in `/root/.local/` rather than `/usr/local/lib/python*/site-packages/` where Home Assistant expects them. That part was reverted in [#358](https://github.com/home-assistant/docker/pull/358).

[#401](https://github.com/home-assistant/docker/pull/401) migrated the workflow to the new `build-image` action, which uses BuildKit with `mode=max` layer caching backed by GitHub Actions cache. This is what actually makes the multi-stage cache reuse from #343 pay off at CI time — every builder stage's layers are captured and reused across workflow runs.

## What

Adds a `pip-builder` stage that installs Python packages using `--prefix=/opt/pip-packages` (instead of `--user`), then `COPY --link`s the result into `/usr/local/` in the final image — landing packages at `/usr/local/lib/python*/site-packages/` exactly where they were before.

This follows the same pattern already used for ssocr, libcec, PicoTTS, and Telldus. With this in place, a `requirements.txt` change triggers only the `pip-builder` stage; ssocr, libcec, picotts, and telldus remain cache hits. Equally, a version bump in any of those builders leaves the pip layer untouched.

Also makes `cache-gha: true` and `cache-image-tag: latest` explicit in the builder workflow, so caching intent is visible rather than implied by action defaults.