### PR TITLE
Drop redundant faust-cchardet from base image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Brotli==1.2.0
-faust-cchardet==2.1.19
 mysqlclient==2.2.8
 psycopg2==2.9.12


### PR DESCRIPTION
## Summary

Drop `faust-cchardet` from the base image's `requirements.txt`. It is a redundant explicit entry: `faust-cchardet` is a **transitive** dependency in Core, so it lands in the final image regardless of whether the base image installs it.

## Why it's redundant

`faust-cchardet` is required by the `axis` and `pytouchline_extended` integration libraries, both of which declare it in their `install_requires`. Those integrations are part of `requirements_all.txt`, so `faust-cchardet` is pulled from the [wheels index](https://wheels.home-assistant.io/musllinux-index/faust-cchardet/) during the Core image build anyway.

Verified in a current Core image:

```
$ pip show faust-cchardet
Version: 2.1.19
Required-by: axis, pytouchline_extended
```

Contrast with the other three entries, which have **no** dependents and therefore must stay explicit:

```
$ pip show Brotli mysqlclient psycopg2
Brotli       Required-by:
mysqlclient  Required-by:
psycopg2     Required-by:
```

So `faust-cchardet` is the only one of the four that another package pulls in on its own.

## Why it was here in the first place

It was originally provisioned in the base image because aiohttp used `cchardet` (and later its `faust-cchardet` fork) as an *optional* charset-detection speed-up — an extra, not a hard dependency, so it had to be installed explicitly. That's what #260 did when it replaced the abandoned `cchardet`. aiohttp 3.9 [dropped built-in `chardet`/`cchardet` detection](https://docs.aiohttp.org/en/stable/client_advanced.html#character-set-detection) (charset resolution now defaults to UTF-8 unless a `fallback_charset_resolver` is configured), so that reason no longer applies. The only remaining consumers hard-declare the dependency, which is why the explicit entry can go.

## Effect

- The package remains in the final Core image (transitive via `axis`/`pytouchline_extended`), just installed in the Core layer instead of the base layer.
- Its version is governed by Core's `package_constraints` (`faust-cchardet>=2.1.18`) rather than the pin removed here. (Separately, that constraint is worth tightening to an exact pin to match the `grpcio`/`protobuf`/`numpy` convention for build-from-source C-extensions — a Core-repo change.)

## Context

This came out of investigating the failing Dependabot bump #416 (`faust-cchardet` 2.1.19 → 2.1.20). That bump failed only because of a PyPI upload race — the 2.1.20 sdist landed ~20 min after CI ran, and there is no `cp314` wheel on PyPI, so HA builds it from source. It's since been built and published to the wheels index, so #416 would pass on rebase — but for the base image the entry is simply unnecessary. A matching cleanup removes the same unused pin from Supervisor's `requirements.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
